### PR TITLE
Fix:task_spec.rb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@
 
 # Ignore .idea files
 .idea
+
+vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'yard', '>= 0.9.20'
 group :development, :test do
   gem 'rspec-rails', '~> 3.8'
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-byebug'
   gem 'faker'
   gem 'factory_bot_rails'
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    sequence(:title, "title_1")
+    title { 'Task' }
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,9 +1,15 @@
 FactoryBot.define do
   factory :task do
-    title { 'Task' }
+    sequence(:title, "title_1")
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+    association :project
+
+    trait :done do
+      status { :done }
+      completion_date { Time.current.yesterday }
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,4 +59,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include FactoryBot::Syntax::Methods
+  config.include ApplicationHelper
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -110,11 +110,11 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
       # binding.pryで実行。Task.countは0だから削除はOK。TaskってタイトルをTask was successfully ~で判別している？titleをsequenceにした。
-      it 'Taskが削除されること' do
+      fit 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_content task.title
+        expect(find('.task_list')).not_to have_content task.title
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -109,8 +109,7 @@ RSpec.describe 'Task', type: :system do
 
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      # binding.pryで実行。Task.countは0だから削除はOK。TaskってタイトルをTask was successfully ~で判別している？titleをsequenceにした。
-      fit 'Taskが削除されること' do
+      it 'Taskが削除されること' do
         visit project_tasks_path(project)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept


### PR DESCRIPTION
## 概要
spec/system/task_spec.rbを修正しました。

- 各テストにおいて、変数ではなくletを使用しました。

- "it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること'"
エラーを修正しました。
titleが表示されていなかったので、binding.pryで中身を確認したところ、データは保持されていました。
viewファイルを確認したところ、"target: _blank"で別タブを開く挙動をしていため、テストコードを対応させました。

- "it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do"
エラーを修正しました。
期待する年月日の表示と実際のviewファイルの表示が異なっていたため、テストコードをviewファイルに合わせました。
application_helperのshort_timeメソッドを読み込むため、rails_helper.rbでincludeしました。

- " it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do"
FactoryBotのtraitを使用する形に修正しました。
letで切り出したのですが、Task編集の他の正常系テストとは異なり、既に完了しているタスクを作成する必要があったので、context '正常系（ステータスが既に完了している場合）' doとして別枠にしました。

- " it 'Taskが削除されること' do"
エラーを修正しました。
binding.pryで確認したところ、タスクの削除自体はできていたのですが、FactoryBotで作成されるtitleがTaskだったので、タスク削除後の「Task was successfully〜」というメッセージで判定されてしまい、テストが失敗していたようです。
そのため、FactoryBotで作成するタスクのタイトルをsequenceで連続するタイトルにしました。

### 確認事項
修正するテストケースごとにcommitするべきでした。
今後気をつけます。すみません。
